### PR TITLE
Bump time dependency max version to 'time <= 1.6.0.1'

### DIFF
--- a/memoization-utils.cabal
+++ b/memoization-utils.cabal
@@ -18,7 +18,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , containers >= 0.5.6.2
                      , lrucache > 1.2 && < 1.3
-                     , time >= 1.4 && < 1.6
+                     , time >= 1.4 && <= 1.6.0.1
                      , time-units > 1 && < 2
   default-language:    Haskell2010
 


### PR DESCRIPTION
I'm getting this dump when creating a cabal sandbox with GHC 1.8.2

`Resolving dependencies...
cabal: Could not resolve dependencies:
trying: CloudLisp-0.1.0.0 (user goal)
trying: ghc-8.0.2/installed-8.0... (dependency of ghc-mod-5.8.0.0)
next goal: memoization-utils (dependency of CloudLisp-0.1.0.0)
rejecting: memoization-utils-0.1.0.1, memoization-utils-0.1.0.0 (conflict: ghc
=> time==1.6.0.1/installed-1.6..., memoization-utils => time>=1.4 && <1.6)
Backjump limit reached (currently 2000, change with --max-backjumps or try to
run with --reorder-goals).`

Attempting to fix it by bumping the time version in this library.
(Was there any reason that 1.6 was chosen as the upper bound?)